### PR TITLE
fix: resolve Vercel build trace collection error

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,22 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+  experimental: {
+    outputFileTracingExcludes: {
+      '*': [
+        './node_modules/@swc/core-linux-x64-gnu',
+        './node_modules/@swc/core-linux-x64-musl',
+        './node_modules/@esbuild/linux-x64',
+      ],
+    },
+  },
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '**',
+      },
+    ],
+  },
+}
 
 module.exports = nextConfig


### PR DESCRIPTION
- Add experimental outputFileTracingExcludes to prevent stack overflow during build trace collection
- Add image configuration to support Next.js Image component with remote images
- This fixes the "Maximum call stack size exceeded" error during Vercel deployment

The error was occurring in Next.js 14.0.0 during the build trace collection phase.